### PR TITLE
Fix "speak" functionality to avoid in-place object mutation

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,7 +8,12 @@ const app = Elm.SpeakAndSpell.init({
 
 // Instantiate Speech Synth API
 const synth = window.speechSynthesis
-const utter = new SpeechSynthesisUtterance()
+
+function speak(message) {
+  const utter = new SpeechSynthesisUtterance()
+  utter.text = message;
+  synth.speak(utter);
+}
 
 // Pause/Resume Speech Synth API (SetSound On | Off)
 app.ports.sound.subscribe(function (message) {
@@ -22,12 +27,10 @@ app.ports.sound.subscribe(function (message) {
 
 // We receive the whole word here and speak it
 app.ports.speak.subscribe(function (message) {
-  utter.text = message
-  synth.speak(utter)
+  speak(message);
 })
 
 // We receive the split word here and spell it
 app.ports.spell.subscribe(function (message) {
-  utter.text = message
-  synth.speak(utter)
+  speak(message);
 })


### PR DESCRIPTION
When I type letters in quick succession, the speaking functionality doesn't work as expected by saying the wrong letters. The solution presented in this PR is to create a new instance of `SpeechSynthesisUtterance` each time `window.speechSynthesis.speak` is called. Because "speaking" each letter takes time, if the user types faster than the computer can speak, the same `utter` object's `text` property is overwritten, creating a "debounce" effect.